### PR TITLE
Forwarding typo and NO_RESPONSE_PAGE parameter

### DIFF
--- a/Controller/ResponseController.php
+++ b/Controller/ResponseController.php
@@ -25,8 +25,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 
-/* 
-*  	Powered by the WCE Community 
+/*
+*  	Powered by the WCE Community
 *	Worst code ever presents... The ResponseController !
 */
 
@@ -37,9 +37,9 @@ class ResponseController extends Controller
     {
         $datas = array();
 
-		
+
 		if (isset($_POST["DATA"])) {
-		
+
 			$message="message=".$_POST["DATA"];
 			$pathfile="pathfile=".$this->p("jrk_sips_pathfile");
 			$path_bin = $this->p("jrk_sips_response");
@@ -302,7 +302,7 @@ class ResponseController extends Controller
 
         $this->get('session')->getFlashBag()->add('sips_request_details_auto', $datas);
 
-        if ($this->hp('jrk_sips_controller_response')) {
+        if ($this->hp('jrk_sips_controller_auto_response')) {
             $response = $this->forward($this->p("jrk_sips_controller_auto_response"));
         } else {
             $response = $this->forward($this->routeToControllerName($this->p("jrk_sips_route_auto_response")));

--- a/Services/JRKPaymentSips.php
+++ b/Services/JRKPaymentSips.php
@@ -24,8 +24,8 @@ namespace JRK\PaymentSipsBundle\Services;
 use Symfony\Component\DependencyInjection\ContainerInterface as Container;
 
 
-/* 
-*  	Powered by the WCE Community 
+/*
+*  	Powered by the WCE Community
 *	Worst code ever presents... The JRKPaymentSips service !
 */
 class JRKPaymentSips {
@@ -33,7 +33,7 @@ class JRKPaymentSips {
 
 
     public $container;
-	
+
     public $datas_request;
 
     public function __construct(Container $container = null) {
@@ -83,7 +83,7 @@ class JRKPaymentSips {
 
 		$path_bin = $this->p("jrk_sips_request");
 
-	
+
 		if (empty($path_bin)) {
 			throw new \Exception('jrk_payment_sips.files.sips_request is not set');
 		}
@@ -107,9 +107,9 @@ class JRKPaymentSips {
         $parm .= $this->defset($attrbs,"language");
         $parm .= $this->defset($attrbs,"payment_means");
         $parm .= $this->defset($attrbs,"header_flag");
-		
 
-		
+
+
         foreach($attrbs as $k => $v){ $parm .= $k."=".$v." "; $this->datas_request[$k] = $v; }
         /*
 		$parm="$parm capture_day="; $parm="$parm capture_mode="; $parm="$parm bgcolor="; $parm="$parm order_id=";
@@ -123,7 +123,6 @@ class JRKPaymentSips {
         foreach($user_data as $k => $v) { $parm.=$k."=".$v.";";}
         $parm = substr($parm,0,-1);
         */
-        $parm .="data=NO_RESPONSE_PAGE ";
 
         $parm = escapeshellcmd($parm);
 
@@ -139,7 +138,7 @@ class JRKPaymentSips {
         $this->datas_request["error"] = $tableau[2];
         $this->datas_request["render"] = $tableau[3];
         $this->datas_request["path_bin"] = $path_bin;
-		
+
 		if (( $this->datas_request["code"] == "" ) && ( $this->datas_request["error"] == "" ) ) {
             throw new \Exception("call to $path_bin failed");
         }
@@ -156,12 +155,12 @@ class JRKPaymentSips {
 
         return $this->datas_request["render"];
     }
-	
+
 	public function getCurrencySipsCode($currency_iso)
     {
-		if (preg_match('#^([0-9]+)$#',$currency_iso)) 
+		if (preg_match('#^([0-9]+)$#',$currency_iso))
 			return $currency_iso;
-		
+
         $currencies = array(
             "EUR" => "978","USD" => "840",'EUR' => '978', 'USD' => '840','CHF' => '756','GBP' => '826',
             'CAD' => '124','JPY' => '392', 'MXP' => '484','TRL' => '792','AUD' => '036','NZD' => '554',


### PR DESCRIPTION
Hi,

Two fixes here.

First, there was a typo in ResponseController for forwarding the response, between regular response and auto response.

Then, as stated in Atos/SIPS doc, the NO_RESPONSE_PAGE parameter was making the bank server use GET instead of POST for the response calls :

> NO_RESPONSE_PAGE : Ce mot clé supprime l’affichage de la page de réponse à l’internaute. Il est ainsi directement reconnecté à la boutique du commerçant, sur l’URL paramétrée dans le champ normal_return_url ou cancel_return_url suivant que la transaction a été acceptée ou refusée.
> 
> L’utilisation de cette option modifie le protocole de la réponse renvoyée sur les URL paramétrées dans les champs normal_return_url et cancel_return_url. La réponse cryptée n’est plus envoyée en méthode POST, mais en méthode GET. La méthode GET ne permettant pas de véhiculer de grosses variables, tous les champs de la réponse ne sont pas renvoyés.

 ResponseController expects a POST callback.
